### PR TITLE
loaded-latency: always measure TSC frequency on x86

### DIFF
--- a/loaded-latency/rdtsc.h
+++ b/loaded-latency/rdtsc.h
@@ -28,15 +28,25 @@ static inline unsigned long read_cntfreq(void) {
     return args.hwclock_freq;
 }
 
+unsigned long estimate_hwclock_freq(long cpu_num, size_t n, int verbose, struct timeval target_measurement_duration);
+
 static inline unsigned long get_default_cntfreq(void) {
 
-    const unsigned long default_cntfreq = 2900000000;
+    const struct timeval target_measurement_duration = { .tv_sec = 0, .tv_usec = 100000 };
+    unsigned long hwclock_freq;
+    long cpu_num = 0;       // XXX: measure on CPU0, assume it is online
+    size_t num_samples = 1;
+    int verbose = 0;
 
-    printf("Assuming hwcounter frequency = %lu Hz\n", default_cntfreq);
-    printf("Use --hwclock-freq to override\n");
-    printf("Use --estimate-hwclock-freq to measure an estimate.\n");
+    printf("Measuring TSC frequency on CPU0 for %lu.%06lu seconds... ",
+            target_measurement_duration.tv_sec, target_measurement_duration.tv_usec);
+    fflush(stdout);
+    hwclock_freq = estimate_hwclock_freq(cpu_num, num_samples, verbose, target_measurement_duration);
+    printf("%lu Hz\n", hwclock_freq);
+    printf("Use --hwclock-freq to override this result.\n");
+    printf("Use --estimate-hwclock-freq to do longer measurements.\n\n");
 
-    return default_cntfreq;
+    return hwclock_freq;
 }
 
 


### PR DESCRIPTION
The hwclock is used to compute bandwidth.  However, for x86, the TSC frequency varies by system, so unless --hwclock-freq is used to provide an accurate frequency, the reported bandwidth is not correct.

This patch has x86 to always measure the TSC frequency instead of using a fixed frequency.  The measurement duration is for 0.1 seconds.  This is supported by enhancing the estimation routine for sub-second measurement.

--estimate-hwclock-freq now also uses the updated routine, dropping the best/worst out of 12 samples.